### PR TITLE
fix(pom): 添加 Maven 编译器源码和目标版本配置

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,8 @@
     <description>JManus - AI Agent Management System built on Spring AI Alibaba</description>
     <properties>
         <java.version>17</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <jsoup-version>1.18.1</jsoup-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
为确保项目使用正确的 Java 版本进行编译，显式设置了
maven.compiler.source 和 maven.compiler.target 属性，使其与 java.version 属性保持一致