### PR TITLE
fix(DynamicModelEntity):修复dynamic_models表初始化api_key字段长度不足

### DIFF
--- a/src/main/java/com/alibaba/cloud/ai/lynxe/model/entity/DynamicModelEntity.java
+++ b/src/main/java/com/alibaba/cloud/ai/lynxe/model/entity/DynamicModelEntity.java
@@ -32,7 +32,7 @@ public class DynamicModelEntity {
 	@Column(nullable = false)
 	private String baseUrl;
 
-	@Column(nullable = false)
+	@Column(nullable = false, columnDefinition = "TEXT")
 	private String apiKey;
 
 	@Convert(converter = MapToStringConverter.class)


### PR DESCRIPTION
### Describe what this PR does / why we need it
项目初始化启动后，创建默认模型显示成功，但是无跳转
<img width="605" height="175" alt="Snipaste_2025-12-18_18-19-17" src="https://github.com/user-attachments/assets/337d828e-84a5-44bc-b2cb-e68de5c7751a" />
服务报错显示api_key字段长度不够
<img width="1818" height="395" alt="Snipaste_2025-12-18_18-20-20" src="https://github.com/user-attachments/assets/d5bdbefc-1fa3-47fb-9493-724425b796af" />
我DB连的MySQL，创建的表dynamic_models 默认api_key字段长度255
<img width="712" height="498" alt="image" src="https://github.com/user-attachments/assets/c3275116-0b12-4bde-b00d-05e89d7808b1" />

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it
我们并无法控制用户的api_key长度，所以我建议将api_key的db数据格式由varchar 调整为text

### Describe how to verify it
调整为text后 服务启动可以正常跳转，默认模型也成功写入
<img width="645" height="145" alt="image" src="https://github.com/user-attachments/assets/5e8bdd7f-dc19-43c0-95de-79854e017597" />

### Special notes for reviews
